### PR TITLE
Added per-app page visits extractor

### DIFF
--- a/modules/marketplace/templates/apps/monolith/settings/aggregator.ini
+++ b/modules/marketplace/templates/apps/monolith/settings/aggregator.ini
@@ -14,7 +14,7 @@ targets = es
 
 [source:ga]
 id = ga-pageviews
-use = monolith.aggregator.plugins.ganalytics.GoogleAnalytics
+use = monolith.aggregator.plugins.ganalytics.GAPageViews
 metrics = ga:pageviews
 dimensions = browser
 oauth_token = %(here)s/auth.json
@@ -22,9 +22,17 @@ profile_id = 67582515
 
 [source:ga2]
 id = ga-visitors
-use = monolith.aggregator.plugins.ganalytics.GoogleAnalytics
+use = monolith.aggregator.plugins.ganalytics.GAVisits
 metrics = ga:visits
 dimensions = browser
+oauth_token = %(here)s/auth.json
+profile_id = 67582515
+
+[source:ga3]
+id = ga-per-app-visits
+use = monolith.aggregator.plugins.ganalytics.GAPerAppVisits
+metrics = ga:visits
+dimensions = ga:customVarValue7
 oauth_token = %(here)s/auth.json
 profile_id = 67582515
 


### PR DESCRIPTION
This depends on the latest change to monolith-aggregator to find the new Google analytics extraction classes. We'll need to time this config change along with the push(es).
