### PR TITLE
Added configs for gross-revenue in Monolith

### DIFF
--- a/modules/marketplace/templates/apps/monolith_aggregator/admin/aggregator.ini
+++ b/modules/marketplace/templates/apps/monolith_aggregator/admin/aggregator.ini
@@ -8,7 +8,8 @@ history = <%= db_uri %>
 sources = ga, ga2, mkt-installs, mkt-new-user, mkt-app-submitted,
           mkt-new-review, mkt-total-user, mkt-total-devs,
           apps-added-by-package-type, apps-added-by-premium-type,
-          apps-avail-by-package-type, apps-avail-by-premium-type
+          apps-avail-by-package-type, apps-avail-by-premium-type,
+          gross-revenue
 targets = sql
 
 [phase:load]
@@ -123,6 +124,16 @@ field = apps_available_premium_count
 dimensions = region, premium_type
 endpoint = <%= mkt_endpoint %>
 password-file = %(here)s/monolith.password.ini
+
+[source:gross-revenue]
+id = gross-revenue
+use = monolith.aggregator.plugins.solitude.SolitudeReader
+type = gross_revenue
+field = gross_revenue
+dimensions = app_id
+endpoint = <%= mkt_transaction_endpoint %>
+password-file = %(here)s/monolith.password.ini
+keys-file = %(here)s/solitude_aws_keys.ini
 
 [target:sql]
 id = sql

--- a/modules/marketplace/templates/apps/monolith_aggregator/admin/solitude_aws_keys.ini
+++ b/modules/marketplace/templates/apps/monolith_aggregator/admin/solitude_aws_keys.ini
@@ -1,0 +1,4 @@
+[auth]
+access_key = <%= solitude_access_key %>
+secret_key = <%= solitude_secret_key %>
+bucket = <%= solitude_bucket %>


### PR DESCRIPTION
This requires some new things:
- The Solitude AWS keys defined and set up to populate the ini file.
- A new endpoint defined to point to zamboni's transaction API. I named it `mkt_transaction_endpoint` and it should look something like this: `https://marketplace.firefox.com/api/v1/transaction/:transaction_id/`
