### PR TITLE
uwsgi: add support for stats.

### DIFF
--- a/modules/marketplace/manifests/apps/olympia/web_instance.pp
+++ b/modules/marketplace/manifests/apps/olympia/web_instance.pp
@@ -11,6 +11,7 @@ define marketplace::apps::olympia::web_instance(
   $timeout = '90',
   $user = 'mkt_prod',
   $uwsgi_max_requests = '5000',
+  $uwsgi_stats = false,
   $worker_class = 'sync',
   $worker_name = 'addons-olympia-dev',
   $workers = 12,
@@ -44,6 +45,7 @@ define marketplace::apps::olympia::web_instance(
     user         => $user,
     workers      => $workers,
     lazy_apps    => false,
+    stats        => $uwsgi_stats,
   }
 
   if $nginx_settings {

--- a/modules/uwsgi/manifests/instance.pp
+++ b/modules/uwsgi/manifests/instance.pp
@@ -11,6 +11,7 @@ define uwsgi::instance(
   $log_syslog = true,
   $max_requests = '5000',
   $scl = undef,
+  $stats = false,
   $use_unix_socket = true,
   $workers = 4,
 ) {

--- a/modules/uwsgi/templates/uwsgi.ini
+++ b/modules/uwsgi/templates/uwsgi.ini
@@ -29,3 +29,6 @@ harakiri-verbose
 <% if @lazy_apps -%>
 lazy-apps
 <% end -%>
+<% if @stats -%>
+stats = /var/tmp/stats-<%= @app_name %>.sock
+<% end -%>


### PR DESCRIPTION
Defines a stats socket which allows us to use uwsgi-top to see uwsgi worker metrics.

r? @oremj 
