### PR TITLE
Send /newsletter-signup to fireplace

### DIFF
--- a/modules/marketplace/templates/nginx/marketplace.conf
+++ b/modules/marketplace/templates/nginx/marketplace.conf
@@ -290,6 +290,7 @@ server {
     rewrite ^/fxa-authorize$ /server.html break;
     rewrite ^/fxa/authorize$ https://$server_name/fxa-authorize break;
     rewrite ^/new$ /server.html break;
+    rewrite ^/newsletter-signup$ /server.html break;
     rewrite ^/nominate.* https://blog.mozilla.org/apps/2014/11/08/got-a-favorite-app-on-firefox-marketplace-lets-feature-it/ permanent;
     rewrite ^/partners/.* /server.html break;
     rewrite ^/popular$ /server.html break;


### PR DESCRIPTION
Going to https://marketplace.allizom.org/newsletter-signup 404s but if you go to https://marketplace.allizom.org/settings at mobile width and click "Sign up for our newsletter" it works. This should make it work either way.
