### PR TITLE
marketplace:nginx: remove fxa authorize redirect, cleanup as part of bug 1097198.

### DIFF
--- a/modules/marketplace/templates/nginx/marketplace.conf
+++ b/modules/marketplace/templates/nginx/marketplace.conf
@@ -288,7 +288,6 @@ server {
     rewrite ^/feed/.* /server.html break;
     rewrite ^/feedback$ /server.html break;
     rewrite ^/fxa-authorize$ /server.html break;
-    rewrite ^/fxa/authorize$ https://$server_name/fxa-authorize break;
     rewrite ^/new$ /server.html break;
     rewrite ^/newsletter-signup$ /server.html break;
     rewrite ^/nominate.* https://blog.mozilla.org/apps/2014/11/08/got-a-favorite-app-on-firefox-marketplace-lets-feature-it/ permanent;


### PR DESCRIPTION
r? @oremj 