### PR TITLE
Send /website/2 to fireplace

### DIFF
--- a/modules/marketplace/templates/nginx/marketplace.conf
+++ b/modules/marketplace/templates/nginx/marketplace.conf
@@ -290,6 +290,7 @@ server {
     rewrite ^/terms-of-use$ /server.html break;
     rewrite ^/tests$ /server.html break;
     rewrite ^/user/.* /server.html break;
+    rewrite ^/website/.* /server.html break;
 
     # bug 1114675
     location ~ ^/discovery.* {


### PR DESCRIPTION
We now have websites on Marketplace and the URLs are like: https://marketplace-altdev.allizom.org/website/2. You can access this page through https://marketplace-altdev.allizom.org/website/2?src=search but not directly.

Eventually I think we'll need `/website/2/issue` so I left this vague but I can make it more specific if needed.

r? @jasonthomas 